### PR TITLE
Allow disabling signups

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Environment variables
   The logo for the brand, defaults to ``/brands/rapidpro/logo.png``.
 
 *BRANDING_ALLOW_SIGNUPS*
-  Boolean for whether or not to allow signups, defaults to ``True``.
+  Set to `off` to disable, defaults to `on`
 
 *RAVEN_DSN*
   The DSN for Sentry

--- a/settings.py
+++ b/settings.py
@@ -147,7 +147,7 @@ BRANDING = {
         'favico': env('BRANDING_FAVICO', 'brands/rapidpro/rapidpro.ico'),
         'splash': env('BRANDING_SPLASH', '/brands/rapidpro/splash.jpg'),
         'logo': env('BRANDING_LOGO', '/brands/rapidpro/logo.png'),
-        'allow_signups': env('BRANDING_ALLOW_SIGNUPS', True),
+        'allow_signups': env('BRANDING_ALLOW_SIGNUPS', 'on') == 'on',
         'tiers': dict(import_flows=0, multi_user=0, multi_org=0),
         'bundles': [],
         'welcome_packs': [dict(size=5000, name="Demo Account"), dict(size=100000, name="UNICEF Account")],


### PR DESCRIPTION
This setting needs to be a boolean - currently if you set it to the string `'False'` that will evaluate to `True`. This commit allows it to be set to off instead, similar to other settings in this file.