### PR TITLE
fix whitenoise

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -108,7 +108,6 @@ if AWS_STORAGE_BUCKET_NAME:
 
 if not AWS_STATIC:
     STATIC_URL = '/sitestatic/'
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
     MIDDLEWARE_CLASSES = list(MIDDLEWARE_CLASSES) + ['whitenoise.middleware.WhiteNoiseMiddleware']
 
 COMPRESS_ENABLED = env('DJANGO_COMPRESSOR', 'on') == 'on'


### PR DESCRIPTION
This whitenoise.storage.CompressedManifestStaticFilesStorage is causing some of the static files not to load and breaking some functionality including the message export.

It doesn't really make a difference in the size of the page.