### PR TITLE
Add AWS_S3_ENDPOINT_URL setting

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -80,6 +80,7 @@ AWS_DEFAULT_ACL = env('AWS_DEFAULT_ACL', '')
 AWS_LOCATION = env('AWS_LOCATION', '')
 AWS_STATIC = env('AWS_STATIC', False)
 AWS_MEDIA = env('AWS_MEDIA', False)
+AWS_S3_ENDPOINT_URL = env('AWS_S3_ENDPOINT_URL', None)
 
 if AWS_STORAGE_BUCKET_NAME:
     # Tell django-storages that when coming up with the URL for an item in S3 storage, keep


### PR DESCRIPTION
This is a setting provided by Boto for a custom S3 URL to use when connecting to S3